### PR TITLE
Feature redhat

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,8 @@ HOSTS = {
 
 def ssh(host, user = USER, password = PASSWORD)
   (@ssh_connections ||= {})[host.to_s] ||= begin
-    Net::SSH.start(HOSTS[host.to_s], user, :password => password)
-  end
+                                             Net::SSH.start(HOSTS[host.to_s], user, :password => password)
+                                           end
 end
 
 def scp(host, local_path, remote_path, user = USER, password = PASSWORD)
@@ -21,22 +21,38 @@ def razor(*a)
   puts ssh(:gold).exec!(['sudo /opt/razor/bin/razor', *a].join(' '))
 end
 
+def download(options)
+  url = options[:url]
+  file_name = options[:as] || File.basename(url)
+  folder = options[:to] || "."
+
+  file_path = folder + "/" + file_name
+
+  command = "curl #{url} -o #{file_path}"
+  if File.exists?(file_path)
+    puts "File #{file_path} already exists. skipping download!"
+  else
+    system(command) or raise "Download command failed: #{command}"
+  end
+end
+
+
 namespace :microkernel do
 
   url = 'https://github.com/downloads/puppetlabs/Razor/rz_mk_dev-image.0.8.9.0.iso'
-  path = File.basename(url)
-  remote_path = "/tmp/#{path}"
+  file_name = File.basename(url)
+  remote_file_name = "/tmp/#{file_name}"
 
-  file path do
-    system("wget #{url}")
+  file file_name do
+    download(:url => url)
   end
 
-  task :upload => path do
-    scp(:gold, path, remote_path)
+  task :upload => file_name do
+    scp(:gold, file_name, remote_file_name)
   end
 
   task :setup => :upload do
-    razor('image', 'add', 'mk', remote_path)
+    razor('image', 'add', 'mk', remote_file_name)
   end
 end
 
@@ -45,19 +61,19 @@ task :microkernel => 'microkernel:setup'
 namespace :ubuntu do
 
   url = 'http://releases.ubuntu.com/precise/ubuntu-12.04-server-amd64.iso'
-  path = File.basename(url)
-  remote_path = "/tmp/#{path}"
+  file_name = File.basename(url)
+  remote_file_name = "/tmp/#{file_name}"
 
-  file path do
-    system("wget #{url}")
+  file file_name do
+    download(:url => url)
   end
 
-  task :upload => path do
-    scp(:gold, path, remote_path)
+  task :upload => file_name do
+    scp(:gold, file_name, remote_file_name)
   end
 
   task :setup => :upload do
-    razor('image', 'add', 'os', remote_path, 'ubuntu_precise', '12.04')
+    razor('image', 'add', 'os', remote_file_name, 'ubuntu_precise', '12.04')
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -78,3 +78,45 @@ namespace :ubuntu do
 end
 
 task :ubuntu => 'ubuntu:setup'
+
+namespace :scientific do
+
+  url = 'ftp://ftp.scientificlinux.org/linux/scientific/6.2/x86_64/iso/SL-62-x86_64-2012-02-06-boot.iso'
+  file_name = File.basename(url)
+  remote_file_name = "/tmp/#{file_name}"
+
+  file file_name do
+    download(:url => url)
+  end
+
+  task :upload => file_name do
+    scp(:gold, file_name, remote_file_name)
+  end
+
+  task :setup => :upload do
+    razor('image', 'add', 'os', remote_file_name, 'scientific', '6.2')
+  end
+end
+
+task :scientific => 'scientific:setup'
+
+namespace :centos do
+
+  url = "http://mirror.metrocast.net/centos/6.2/isos/x86_64/CentOS-6.2-x86_64-minimal.iso"
+  file_name = File.basename(url)
+  remote_file_name = "/tmp/#{file_name}"
+
+  file file_name do
+    download(:url => url)
+  end
+
+  task :upload => file_name do
+    scp(:gold, file_name, remote_file_name)
+  end
+
+  task :setup => :upload do
+    razor('image', 'add', 'os', remote_file_name, 'centos', '6.2')
+  end
+end
+
+task :centos => 'centos:setup'


### PR DESCRIPTION
NOTE: this builds on my other pull request.

Makes centos_6 example work. I ran into issues with the ubuntu example. Things like the installer not finding kernels or not partitioning the disks correctly. as discussed
https://github.com/puppetlabs/Razor/issues/88

---

```

$ rake centos
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  321M  100  321M    0     0  1394k      0  0:03:56  0:03:56 --:--:-- 1010k
Attempting to add, please wait...

New image added successfully
Added Image:
 UUID =>  7heF69c3hApMqxgzOWEmxd
 Type =>  OS Install
 ISO Filename =>  CentOS-6.2-x86_64-minimal.iso
 Path =>  /opt/razor/image/os/7heF69c3hApMqxgzOWEmxd
 Status =>  Valid
 OS Name =>  centos
 OS Version =>  6.2
```

---

```
root@gold:/opt/razor# bin/razor model add template="centos_6" label="install_centos_6" image_uuid="7heF69c3hApMqxgzOWEmxd"
--- Building Model (centos_6): 

Please enter node hostname prefix (will append node number) (example: node) 
default: node
(QUIT to cancel)
 > centos
Please enter root password (> 8 characters) (example: P@ssword!) 
default: test1234
(QUIT to cancel)
 > qwert123
Model created
 Label =>  install_centos_6
 Template =>  linux_deploy
 Description =>  CentOS 6 Model
 UUID =>  o7UK2SV4B5CBZFHYZOSdl
 Image UUID =>  7heF69c3hApMqxgzOWEmxd

root@gold:/opt/razor# bin/razor policy add --template=linux_deploy --tags=virtualbox_vm --enabled --label="centos_6" --model=o7UK2SV4B5CBZFHYZOSdl
Policy created
 UUID =>  2kMiVmLjgj1nnMwvfLJvkX
 Line Number =>  0
 Label =>  centos_6
 Enabled =>  true
 Template =>  linux_deploy
 Description =>  Policy for deploying a Linux-based operating system.
 Tags =>  [virtualbox_vm]
 Model Label =>  install_centos_6
 Broker Target =>  none
 Currently Bound =>  0
 Maximum Bound =>  0
 Bound Counter =>  0

root@gold:/opt/razor# bin/razor node
Discovered Nodes
         UUID           Last Checkin  Status                  Tags                   
3R5ouQeb58DBlI5kcPX8s5  35 sec        A       [memsize_500MiB,nics_1,virtualbox_vm]  
root@gold:/opt/razor# bin/razor node 3R5ouQeb58DBlI5kcPX8s5
 UUID =>  3R5ouQeb58DBlI5kcPX8s5
 Last Checkin =>  06-27-12 06:57:33
 Status =>  active
 Tags =>  [memsize_500MiB,nics_1,virtualbox_vm]
 Hardware IDs =>  [0800277E2501]

root@gold:/opt/razor# bin/razor node
Discovered Nodes
         UUID           Last Checkin  Status                  Tags                   
3R5ouQeb58DBlI5kcPX8s5  3 sec         B       [memsize_500MiB,nics_1,virtualbox_vm]  
```
