### PR TITLE
Force use of the PCnet-FAST III nic emulation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,7 @@ Vagrant::Config.run do |config|
     box_config.ssh.port = 2222
 
     box_config.vm.customize ["modifyvm", :id, "--name", 'agent1.localdomain']
+    box_config.vm.customize ["modifyvm", :id, "--nictype1", 'Am79C973']
   end
 
   # The url from where the 'config.vm.box' box will be fetched if it


### PR DESCRIPTION
On OSX with VirtualBox 4.1, the default E1000 nic emulation does not properly pxe boot. Forcing the FAST III nic during VM creation allows razor to launch successfully.
